### PR TITLE
Helm charts for TAC

### DIFF
--- a/charts/trusted-attestation-controller/Chart.yaml
+++ b/charts/trusted-attestation-controller/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: trusted-attestation-controller
+version: 0.4.0
+appVersion: 0.4.0
+description: Helm chart for Trusted Attestation Controller

--- a/charts/trusted-attestation-controller/README.md
+++ b/charts/trusted-attestation-controller/README.md
@@ -1,0 +1,131 @@
+# Trusted Attestation Controller Helm Chart
+
+Trusted Attestation Controller (TAC) is a K8s controller for reconciling the [QuoteAttestation](https://github.com/intel/trusted-certificate-issuer/blob/main/api/v1alpha1/quoteattestation_types.go) requests initiated by the [Trusted Certificate Service (TCS)](https://github.com/intel/trusted-certificate-issuer). It is a proxy between the TCS and the key server(s) which supports attestation services. The key servers could plugin to the controller by implementing the API provided by the controller.
+
+To learn more check the documentation [here](https://github.com/intel/trusted-attestation-controller).
+
+## Prerequisites
+
+Prerequisites for building and running Trusted Attestation Controller:
+
+- Kubernetes cluster with running [Trusted Certificate Service](https://github.com/intel/trusted-certificate-issuer)
+- Either KMRA or a KMIP-compliant key server exposed via iSecL's Key Broker Service
+
+## Installing the Helm Chart
+
+Use the following command to install TAC.
+
+The Intel's Helm Chart repository:
+
+```console
+$ helm repo add intel https://intel.github.io/helm-charts
+$ helm repo update
+```
+
+Install the chart:
+
+```console
+$ helm install tac intel/trusted-attestation-controller -n intel-system --create-namespace
+```
+
+Use the following command to verify the installation status.
+
+```console
+$ helm ls -n intel-system
+```
+
+## Uninstalling the Chart
+
+In case you want to uninstall TAC, use the following command:
+
+```console
+$ helm delete tac -n intel-system
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the trusted-attestation-controller chart and their default values. You can change the default values either via `helm --set <parameter=value>` or editing the `values.yaml` and passing the file to helm via `helm install -f values.yaml ...` option.
+
+| Parameter | Description | Default 
+| --- | --- | --- |
+| `image.hub`| Image repository | docker.io |
+| `image.name`| Image name | intel/trusted-attestation-controller |
+| `image.tag`| Image tag | Chart's appVersion |
+| `image.pullPolicy`| Image pull policy | IfNotPresent |
+| `plugin`| Name of the plugin to use with TAC | "" |
+| `serviceAccountName`| Service account name | tac-svcact |
+| `metricsPort`| Metrics port | 8443 |
+| `replicas`| Replica count | 1 |
+| `controller.image`| Controller image | .image |
+| `controller.limits.cpu`| CPU limit | 200m |
+| `controller.limits.memory`| Memory limit | 100Mi |
+| `controller.requests.cpu`| CPU request | 100m |
+| `controller.requests.memory`| Memory request | 20Mi |
+| `nullPlugin.image`| Plugin image | .image |
+| `nullPlugin.limits.cpu`| CPU limit | 500m |
+| `nullPlugin.limits.memory`| Memory limit | 100Mi |
+| `nullPlugin.requests.cpu`| CPU request | 100m |
+| `nullPlugin.requests.memory`| Memory request | 20Mi |
+| `kmraPlugin.image`| Plugin image | .image |
+| `kmraPlugin.limits.cpu`| CPU limit | 500m |
+| `kmraPlugin.limits.memory`| Memory limit | 100Mi |
+| `kmraPlugin.requests.cpu`| CPU request | 100m |
+| `kmraPlugin.requests.memory`| Memory request | 20Mi |
+| `kmraPlugin.server.url`| Server URL | "" |
+| `kmraPlugin.server.tls.caCrt`| caCrt | "" |
+| `kmraPlugin.server.url.tls.clientCrt`| clientCrt | "" |
+| `kmraPlugin.server.url.tls.clientKey`| clientKey | "" |
+| `iseclPlugin.image`| Plugin image | .image |
+| `iseclPlugin.limits.cpu`| CPU limit | 500m |
+| `iseclPlugin.limits.memory`| Memory limit | 100Mi |
+| `iseclPlugin.requests.cpu`| CPU request | 100m |
+| `iseclPlugin.requests.memory`| Memory request | 20Mi |
+| `iseclPlugin.kbs.host`| KBS server hostname | localhost |
+| `iseclPlugin.kbs.port`| KBS server port number | 9443 |
+| `iseclPlugin.kbs.tls.caCrt`| base64-encoded CA certificate | "" |
+| `iseclPlugin.kbs.tls.clientKey`| base64-encoded client key | "" |
+| `iseclPlugin.kbs.tls.clientCrt`| base64-encoded client certificate | "" |
+| `iseclPlugin.kbs.token`| Bearer token to access KBS API | "" |
+| `iseclPlugin.sqvs.host`| Host name | "" |
+| `iseclPlugin.sqvs.port`| Port number | "" |
+| `iseclPlugin.kmip.ip`| KMIP ip | "" |
+| `iseclPlugin.kmip.hostname`| KMIP hostname | localhost |
+| `iseclPlugin.kmip.port`| KMIP port number | 5696 |
+| `iseclPlugin.kmip.username`| KMIP username | "" |
+| `iseclPlugin.kmip.password`| KMIP password | "" |
+| `iseclPlugin.kmip.tls.caCert`| base65-encoded CA certificate | "" |
+| `iseclPlugin.kmip.tls.clientKey`| base64-encoded client key | "" |
+| `iseclPlugin.kmip.tls.clientCert`| base64-encoded client certificate | "" |
+
+## KMRA plugin configuration example
+
+Add the configuration:
+
+```console
+export KEY_SERVER="hostname:port" # KMRA server url
+export CA_CERT = "LS0tLS1CRUdJT...." # CA certificate (base64)
+export CLIENT_KEY= "LS0tLS1CRUdJT..." # Client private key (base64)
+export CLIENT_CERT= "LS0tLS1CRUdJ..." # Client certificate (base64)
+```
+
+Add values to values.yaml:
+
+```yaml
+# Example KMRA configuration:
+cat << EOF > values.yaml
+  plugin: "kmra"
+  kmraPlugin:
+    server:
+      url: $KEY_SERVER
+      tls:    
+        caCrt: $CA_CERT
+        clientKey: $CLIENT_KEY
+        clientCert: $CLIENT_CERT
+EOF
+```
+
+Install the chart with your new values:
+
+```console
+helm installl -f values.yaml tac intel/trusted-attestation-controller -n intel-system --create-namespace
+```

--- a/charts/trusted-attestation-controller/templates/NOTES.txt
+++ b/charts/trusted-attestation-controller/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Thank you for installing {{ .Chart.Name }}.

--- a/charts/trusted-attestation-controller/templates/configmap.yaml
+++ b/charts/trusted-attestation-controller/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 55c5974b.tac.intel.com
+kind: ConfigMap
+metadata:
+  name: tac-manager-config
+  namespace: {{ .Release.namespace }}

--- a/charts/trusted-attestation-controller/templates/deployment.yaml
+++ b/charts/trusted-attestation-controller/templates/deployment.yaml
@@ -1,0 +1,305 @@
+{{ $plugins := list "null" "kmra" "isecl" }}
+{{- if not .Values.plugin }}
+{{ $message := printf "`No plugin name selected. Available plugins are: %v" $plugins }}
+{{- fail $message }}
+{{- else if not (has .Values.plugin $plugins) }}
+{{ $message := printf "Invalid plugin name: %q. Valid plugins are: %v" .Values.plugin $plugins }}
+{{- fail $message }}
+{{- end }}
+
+
+{{- /*
+Volume mounts generic to all containers
+*/}}
+{{ define "volumeMounts" -}}
+- mountPath: /plugins
+  name: plugin-socket-dir
+- mountPath: /registration
+  name: registry-socket-dir
+{{- end }}
+
+{{- /*
+NULL plugin container definition
+*/}}
+
+{{ define "nullPluginContainer" -}}
+{{ $image := merge .Values.nullPlugin.image .Values.image -}}
+{{ $imageTag := default .Chart.AppVersion $image.tag -}}
+{{ with .Values.nullPlugin -}}
+- args:
+  {{- toYaml .args | nindent 2 }}
+  - --registry-socket-path=/registration/controller.sock
+  command:
+  {{- toYaml .command | nindent 2 }}
+  image: "{{ $image.hub }}/{{ $image.name }}:{{ $imageTag }}"
+  name: {{ .name }}
+  resources:
+    limits:
+      cpu: {{ .limits.cpu }}
+      memory: {{ .limits.memory }}
+    requests:
+      cpu: {{ .requests.cpu }}
+      memory: {{ .requests.memory }}
+{{- end }}
+  volumeMounts:
+  {{- include "volumeMounts" .| nindent 2 }}
+{{- end }}
+
+{{- /*
+KMRA plugin container definition
+*/}}
+
+{{ define "kmraPluginContainer" -}}
+{{ $image := merge .Values.kmraPlugin.image .Values.image -}}
+{{ $imageTag := default .Chart.AppVersion $image.tag -}}
+{{- with .Values.kmraPlugin -}}
+- args:
+  {{- toYaml .args | nindent 2 }}
+  - --registry-socket-path=/registration/controller.sock
+  command:
+  {{- toYaml .command | nindent 2 }}
+  envFrom:
+  - configMapRef:
+      name: kmra-config
+  image: "{{ $image.hub }}/{{ $image.name }}:{{ $imageTag }}"
+  name: {{ .name }}
+  resources:
+    limits:
+      cpu: {{ .limits.cpu }}
+      memory: {{ .limits.memory }}
+    requests:
+      cpu: {{ .requests.cpu }}
+      memory: {{ .requests.memory }}
+{{- end }}
+  volumeMounts:
+  {{- include "volumeMounts" .| nindent 2 }}
+  - name: kmra-secrets
+    mountPath: /certs/
+    readOnly: true
+{{- end }}
+
+{{- /*
+IsecL plugin container definition
+*/}}
+
+{{ define "iseclPluginContainer" -}}
+{{ $image := merge .Values.iseclPlugin.image .Values.image -}}
+{{ $imageTag := default .Chart.AppVersion $image.tag -}}
+{{ with .Values.iseclPlugin -}}
+- args:
+  {{- toYaml .args | nindent 2 }}
+  - --registry-socket-path=/registration/controller.sock
+  command:
+  {{- toYaml .command | nindent 2 }}
+  image: "{{ $image.hub }}/{{ $image.name }}:{{ $imageTag }}"
+  name: {{ .name }}
+  resources:
+    limits:
+      cpu: {{ .limits.cpu }}
+      memory: {{ .limits.memory }}
+    requests:
+      cpu: {{ .requests.cpu }}
+      memory: {{ .requests.memory }}
+{{- end }}
+  volumeMounts:
+  {{- include "volumeMounts" .| nindent 2 }}
+  - name: tac-config
+    mountPath: /etc/tac
+    readOnly: true
+  - name: kmip-secrets
+    mountPath: /etc/tac/kmip-certs
+    readOnly: true
+  - name: kbs-secrets
+    mountPath: /etc/tac/kbs-certs
+    readOnly: true
+{{- end }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: tac-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --registration-path=/registration/controller.sock
+        - --plugin-name={{ .Values.plugin }}
+        command:
+        - /manager
+        {{- $image := merge .Values.controller.image .Values.image -}}
+        {{- $imageTag := default .Chart.AppVersion $image.tag -}}
+      {{- with .Values.controller }}
+        image: "{{ $image.hub }}/{{ $image.name }}:{{ $imageTag }}"
+        imagePullPolicy: {{ .image.PullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .healthProbePort }}
+          initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .livenessProbe.periodSeconds }}
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .healthProbePort }}
+          initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .readinessProbe.initialDelaySeconds }}
+        resources:
+          limits:
+            cpu: {{ .limits.cpu }}
+            memory: {{ .limits.memory }}
+          requests:
+            cpu: {{ .requests.cpu }}
+            memory: {{ .requests.memory }}
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        {{- include "volumeMounts" . | nindent 8 }}
+      {{- end }}
+{{-
+/* Plugin container(s) definition starts here.
+Currently we support single plugin. When the TAC supports multiple plugins
+then just  remove { else } to add multiple plugin containers.
+*/ -}}
+      {{- if eq .Values.plugin "null" }}
+      {{- include "nullPluginContainer" . | nindent 6 }}
+      {{- else if eq .Values.plugin "kmra" }}
+      {{- include "kmraPluginContainer" . | nindent 6 }}
+      {{- else if eq .Values.plugin "isecl" }}
+      {{- include "iseclPluginContainer" . | nindent 6 }}
+      {{- end }}
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - set -x; chown -R 5000:5000 /registration /plugins
+        image: busybox
+        name: decode-secrets
+        volumeMounts:
+        {{- include "volumeMounts" . | nindent 8 }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: plugin-socket-dir
+      - emptyDir: {}
+        name: registry-socket-dir
+      {{- if eq .Values.plugin "kmra" }}
+      - name: kmra-secrets
+        secret:
+          secretName: kmra-secrets
+      {{- else if eq .Values.plugin "isecl" }}
+      - name: tac-config
+        configMap:
+          name: tac-config
+      - name: kbs-secrets
+        secret:
+          secretName: kbs-secrets
+      - name: kmip-secrets
+        secret:
+          secretName: kmip-secrets
+      {{- end }}
+
+
+{{ if eq .Values.plugin "kmra" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kmra-config
+  namespace: {{ .Release.Namespace }}
+data:
+  KEY_SERVER: {{ required "A valid kmraPlugin.server.url entry required!" .Values.kmraPlugin.server.url }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kmra-secrets
+data:
+{{- with .Values.kmraPlugin.server.tls }}
+  ca.crt: {{ required "A valid kmraPlugin.server.tls.caCert entry required!" .caCrt | quote }}
+  client.crt: {{ required "A valid kmraPlugin.server.tls.clientCrt entry required!" .clientCrt | quote }}
+  client.key: {{ required "A valid kmraPlugin.server.tls.clientKey entry required!" .clientKey | quote }}
+{{- end}}
+type: Opaque
+
+{{ else if eq .Values.plugin "isecl" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tac-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |-
+{{- with .Values.iseclPlugin }}
+    kbs:
+      # KBS server hostname/ip-address
+      host: {{ required "A valid iseclPlugin.kbs.host entry required!" .kbs.host }}
+      port: {{ required "A valid iseclPlugin.kbs.port entry required!" .kbs.port }}
+      # Client Certificate and Privatekey paths
+      # Make sure that the KBS client secrets are mounted
+      # at this path: /etc/tac/kbs-certs
+      caCert: "/etc/tac/kbs-certs/ca.crt"
+      clientKey: "/etc/tac/kbs-certs/client.key"
+      clientCert: "/etc/tac/kbs-certs/client.crt"
+      # Bearer token to access KBS API
+      token: {{ required "A valid iseclPlugin.kbs.token entry required!" .kbs.token }}
+    # SGX Quote Verification Service
+    sqvs:
+      host: {{ required "A valid iseclPlugin.sqvs.host entry required!" .sqvs.host }}
+      host: {{ required "A valid iseclPlugin.sqvs.port entry required!" .sqvs.port }}
+    kmip:
+      # Server IP address
+      ip: {{ required "A valid iseclPlugin.kmip.ip entry required!" .kmip.ip }}
+      # Server hostname
+      hostname: {{ .kmip.hostname }}
+      # Server port number defaults to 5696
+      port: {{ .kmip.port }}
+      # base64 encoded username and password to access the server
+      username: {{ .kmip.username }}
+      password: {{ .kmip.password }}
+      # Client Certificate and Privatekey paths
+      # Make sure that the KMIP client secrets are mounted
+      # at this path: /etc/tac/kmip-certs
+      caCert: "/etc/tac/kmip-certs/ca.crt"
+      clientKey: "/etc/tac/kmip-certs/client.key"
+      clientCert: "/etc/tac/kmip-certs/client.crt"
+{{- end}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kbs-secrets
+data:
+{{- with .Values.iseclPlugin.kbs.tls }}
+  ca.crt: {{ required "A valid .iseclPlugin.kbs.tls.caCrt entry required!" .caCrt | quote }}
+  client.crt: {{ required "A valid .iseclPlugin.kbs.tls.clientCrt entry required!" .clientCrt | quote }}
+  client.key: {{ required "A valid .iseclPlugin.kbs.tls.clientKey entry required!" .clientKey | quote }}
+{{- end}}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kmip-secrets
+data:
+{{- with .Values.iseclPlugin.kmip.tls }}
+  ca.crt: {{ required "A valid .iseclPlugin.kmip.tls.caCrt entry required!" .caCrt | quote }}
+  client.crt: {{ required "A valid .iseclPlugin.kmip.tls.clientCrt entry required!" .clientCrt | quote }}
+  client.key: {{ required "A valid .iseclPlugin.kmip.tls.clientKey entry required!" .clientKey | quote }}
+{{- end}}
+type: Opaque
+{{ end }}

--- a/charts/trusted-attestation-controller/templates/role.yaml
+++ b/charts/trusted-attestation-controller/templates/role.yaml
@@ -1,0 +1,103 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tac-leader-election-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tac-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tac-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: tac-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - tcs.intel.com
+  resources:
+  - quoteattestations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tcs.intel.com
+  resources:
+  - quoteattestations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - tcs.intel.com
+  resources:
+  - quoteattestations/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/charts/trusted-attestation-controller/templates/rolebinding.yaml
+++ b/charts/trusted-attestation-controller/templates/rolebinding.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tac-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tac-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: tac-svcact
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tac-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tac-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: tac-svcact
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tac-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tac-role
+subjects:
+- kind: ServiceAccount
+  name: tac-svcact
+  namespace: {{ .Release.Namespace }}

--- a/charts/trusted-attestation-controller/templates/service.yaml
+++ b/charts/trusted-attestation-controller/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: tac-metrics-service
+  namespace: {{ .Release.namespace }}
+spec:
+  ports:
+  - name: https
+    port: {{ .Values.metricsPort }}
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/charts/trusted-attestation-controller/templates/serviceaccount.yaml
+++ b/charts/trusted-attestation-controller/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/trusted-attestation-controller/values.yaml
+++ b/charts/trusted-attestation-controller/values.yaml
@@ -1,0 +1,138 @@
+# Name of the plugin to deploy, one of : "null", "kmra", "isecl".
+# This must be selected on chart installation
+plugin: ""
+
+serviceAccountName: tac-svcact
+metricsPort: 8443
+replicas: 1
+
+# This is the default image used by all the containers (controller and plugins).
+# Could be overwritten by providing container specific 'image' section.
+image:
+  hub: docker.io
+  name: intel/trusted-attestation-controller
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag:
+
+# controller/manager container configuration
+controller:
+  # default to .image
+  image:
+    hub:
+
+  healthProbePort: 8081
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  
+  limits:
+    cpu: 200m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+# Configuration for null-plugin
+nullPlugin:
+  name: null-plugin
+
+  args:
+    - --plugin-name=null
+    - --plugin-socket-path=/plugins/null.sock
+
+  command:
+  - /null-plugin
+  
+  # defaults to .image
+  image:
+    hub:
+
+  limits:
+    cpu: 500m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+# Configuration for kmra-plugin
+kmraPlugin:
+  name: kmra-plugin
+
+  args:
+    - --plugin-name=kmra
+    - --plugin-socket-path=/plugins/kmra.sock
+
+  command:
+    - /kmra-plugin
+
+  # defaults to .image
+  image:
+    hub:
+
+  limits:
+    cpu: 500m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+  # KMRA server configuration must be set on chat installation
+  server:
+    url: "" # KMRA server url
+    tls:
+      caCrt: "" # CA certificate (base64)
+      clientCrt: "" # Client private key (base64)
+      clientKey: "" # Client certificate (base64)
+
+# Configuration for isecl-plugin
+iseclPlugin:
+  name: isecl-plugin
+  
+  args:
+    - --plugin-name=isecl
+    - --plugin-socket-path=/plugins/isecl.sock
+  
+  command:
+    - /isecl-plugin
+
+  # defaults to .image
+  image:
+    hub:
+
+  limits:
+    cpu: 500m
+    memory: 100Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+  
+  kbs:
+    # KBS server hostname/ip-address
+    host: localhost
+    port: 9443
+    tls:
+      caCert: # base64-encoded CA certificate
+      clientKey: # base64-encoded client key
+      clientCert: # base64-encoded client certificate
+    token: # Bearer token to access KBS API
+  # SGX Quote Verification Service
+  sqvs:
+    host:
+    port: 9447
+  # KMIP server configuration
+  kmip:
+    ip:
+    hostname: localhost
+    port: 5696
+    # base64 encoded username and password to access the server
+    username: ""
+    password: ""
+    # tls configuration
+    tls:
+      caCert: # base64-encoded CA certificate
+      clientKey: # base64-encoded client key
+      clientCert: # base64-encoded client certificate


### PR DESCRIPTION
Helm charts for Trusted Attestation Controller

Summary of changes:
- Created helm charts for the trusted attestation controller
- Created values.yaml making it easy to switch between different plugins when using TAC. Change the pluginToUse value to match the plugin you want to use.