### PR TITLE
Fix gpu chart nodeFeatureRule wrong value

### DIFF
--- a/charts/gpu-device-plugin/Chart.yaml
+++ b/charts/gpu-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-gpu
 description: A Helm chart for Intel GPU Device Plugin
 type: application
-version: 0.25.0
+version: 0.25.1
 appVersion: "0.25.0"

--- a/charts/gpu-device-plugin/Chart.yaml
+++ b/charts/gpu-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-gpu
 description: A Helm chart for Intel GPU Device Plugin
 type: application
-version: 0.25.1
+version: 0.25.1-helm0
 appVersion: "0.25.0"

--- a/charts/gpu-device-plugin/templates/gpu.yaml
+++ b/charts/gpu-device-plugin/templates/gpu.yaml
@@ -19,7 +19,7 @@ spec:
 
   nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 4 }}
 ---
-{{ if eq .Values.gpu.nodeFeatureRule true }}
+{{ if eq .Values.nodeFeatureRule true }}
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:


### PR DESCRIPTION
When revamping Gpu chart values, the `nodeFeatureRule` was still left under `gpu` tree. This PR fixes that.