### PR TITLE
trusted-certificate-issuer: add missing rbac rules

### DIFF
--- a/charts/trusted-certificate-issuer/templates/role.yaml
+++ b/charts/trusted-certificate-issuer/templates/role.yaml
@@ -82,6 +82,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - cert-manager.io
   resources:
   - certificaterequests


### PR DESCRIPTION
Due to missing rules 'secrets/finalizer', TCS was not able to remove the finalizer on the secrets.