### PR TITLE
Device plugins 0.28

### DIFF
--- a/charts/device-plugin-operator/Chart.yaml
+++ b/charts/device-plugin-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-operator
 description: A Helm chart for Intel Device Plugins Operator for Kubernetes
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/device-plugin-operator/README.md
+++ b/charts/device-plugin-operator/README.md
@@ -42,6 +42,12 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `manager.image.hub` | `intel` |
+| `manager.image.tag` | `` |
+| `kubeRbacProxy.image.hub` | `gcr.io` |
+| `kubeRbacProxy.image.tag` | `v0.14.1` |
+| `kubeRbacProxy.image.pullPolicy` | `IfNotPresent` |
+| `privateRegistry.registryUrl` | `` |
+| `privateRegistry.registryUser` | `` |
+| `privateRegistry.registrySecret` | `` |
 | `pullPolicy` | `IfNotPresent` |

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_dlbdeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_dlbdeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: dlbdeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com
@@ -52,6 +51,10 @@ spec:
             properties:
               image:
                 description: Image is a container image with DLB device plugin executable.
+                type: string
+              initImage:
+                description: InitImage is a container image with a script that initializes
+                  devices.
                 type: string
               logLevel:
                 description: LogLevel sets the plugin's log level.

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_dsadeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_dsadeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: dsadeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_fpgadeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_fpgadeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: fpgadeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_gpudeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_gpudeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: gpudeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com
@@ -52,7 +51,8 @@ spec:
             properties:
               enableMonitoring:
                 description: EnableMonitoring enables the monitoring resource ('i915_monitoring')
-                  which gives access to all GPU devices on given node.
+                  which gives access to all GPU devices on given node. Typically used
+                  with Intel XPU-Manager.
                 type: boolean
               image:
                 description: Image is a container image with GPU device plugin executable.
@@ -74,7 +74,8 @@ spec:
               preferredAllocationPolicy:
                 description: PreferredAllocationPolicy sets the mode of allocating
                   GPU devices on a node. See documentation for detailed description
-                  of the policies. Only valid when SharedDevNum > 1 is set.
+                  of the policies. Only valid when SharedDevNum > 1 is set. Not applicable
+                  with ResourceManager.
                 enum:
                 - balanced
                 - packed
@@ -82,7 +83,7 @@ spec:
                 type: string
               resourceManager:
                 description: ResourceManager handles the fractional resource management
-                  for multi-GPU nodes
+                  for multi-GPU nodes. Enable only for clusters with GPU Aware Scheduling.
                 type: boolean
               sharedDevNum:
                 description: SharedDevNum is a number of containers that can share

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_iaadeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_iaadeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: iaadeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_qatdeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_qatdeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: qatdeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com

--- a/charts/device-plugin-operator/crds/deviceplugin.intel.com_sgxdeviceplugins.yaml
+++ b/charts/device-plugin-operator/crds/deviceplugin.intel.com_sgxdeviceplugins.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: sgxdeviceplugins.deviceplugin.intel.com
 spec:
   group: deviceplugin.intel.com
@@ -59,8 +58,9 @@ spec:
                 description: Image is a container image with SGX device plugin executable.
                 type: string
               initImage:
-                description: InitImage is a container image with tools (e.g., SGX
-                  NFD source hook) installed on each node.
+                description: InitImage is a container image with tools (i.e., SGX
+                  NFD source hook) installed on each node. Recommendation is to leave
+                  this unset and prefer the SGX NodeFeatureRule instead.
                 type: string
               logLevel:
                 description: LogLevel sets the plugin's log level.

--- a/charts/device-plugin-operator/templates/operator.yaml
+++ b/charts/device-plugin-operator/templates/operator.yaml
@@ -487,6 +487,7 @@ spec:
           runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
       serviceAccountName: default
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/device-plugin-operator/values.yaml
+++ b/charts/device-plugin-operator/values.yaml
@@ -1,3 +1,6 @@
+nodeSelector:
+  kubernetes.io/arch: amd64
+
 manager:
   image:
     hub: intel

--- a/charts/dlb-device-plugin/Chart.yaml
+++ b/charts/dlb-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-dlb
 description: A Helm chart for Intel DLB Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/dlb-device-plugin/README.md
+++ b/charts/dlb-device-plugin/README.md
@@ -33,6 +33,8 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
+| `initImage.hub` | `intel` |
+| `initImage.tag` | `` |
 | `logLevel` | `4` |

--- a/charts/dsa-device-plugin/Chart.yaml
+++ b/charts/dsa-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-dsa
 description: A Helm chart for Intel DSA Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/dsa-device-plugin/README.md
+++ b/charts/dsa-device-plugin/README.md
@@ -33,7 +33,9 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
+| `initImage.hub` | `intel` |
+| `initImage.tag` | `` |
 | `sharedDevNum` | `10` |
 | `logLevel` | `4` |

--- a/charts/gpu-device-plugin/Chart.yaml
+++ b/charts/gpu-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-gpu
 description: A Helm chart for Intel GPU Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/gpu-device-plugin/README.md
+++ b/charts/gpu-device-plugin/README.md
@@ -33,8 +33,11 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
+| `initImage.enable` | `false` |
+| `initImage.hub` | `intel` |
+| `initImage.tag` | `` |
 | `sharedDevNum` | `1` |
 | `resourceManager` | `false` |
 | `enableMonitoring` | `true` |

--- a/charts/gpu-device-plugin/templates/gpu.yaml
+++ b/charts/gpu-device-plugin/templates/gpu.yaml
@@ -21,7 +21,7 @@ spec:
 
   nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 4 }}
 ---
-{{ if eq .Values.nodeFeatureRule true }}
+{{- if eq .Values.nodeFeatureRule true }}
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
@@ -39,4 +39,205 @@ spec:
         - feature: kernel.loadedmodule
           matchExpressions:
             i915: {op: Exists}
-{{ end }}
+---
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-gpu-platform-labeling
+spec:
+  rules:
+  - extendedResources:
+      gpu.intel.com/millicores: "@local.label.gpu.intel.com/millicores"
+      gpu.intel.com/memory.max: "@local.label.gpu.intel.com/memory.max"
+      gpu.intel.com/tiles: "@local.label.gpu.intel.com/tiles"
+    matchFeatures:
+      - feature: local.label
+        matchExpressions:
+          gpu.intel.com/millicores: {op: Exists}
+          gpu.intel.com/memory.max: {op: Exists}
+          gpu.intel.com/tiles: {op: Exists}
+    name: intel.gpu.fractionalresources
+  # generic rule for older and upcoming devices
+  - labels:
+    labelsTemplate: |
+      {{"{{"}} range .pci.device {{"}}"}}gpu.intel.com/device-id.{{"{{"}} .class {{"}}"}}-{{"{{"}} .device {{"}}"}}.present=true
+      {{"{{"}} end {{"}}"}}
+    matchFeatures:
+      - feature: pci.device
+        matchExpressions:
+          class:
+            op: In
+            value:
+            - "0300"
+            - "0380"
+          vendor:
+            op: In
+            value:
+            - "8086"
+    name: intel.gpu.generic.deviceid
+  - labels:
+    labelsTemplate: gpu.intel.com/device-id.0300-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
+    matchFeatures:
+      - feature: pci.device
+        matchExpressions:
+          class:
+            op: In
+            value:
+            - "0300"
+          vendor:
+            op: In
+            value:
+            - "8086"
+    name: intel.gpu.generic.count.300
+  - labels:
+    labelsTemplate: gpu.intel.com/device-id.0380-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
+    matchFeatures:
+      - feature: pci.device
+        matchExpressions:
+          class:
+            op: In
+            value:
+            - "0380"
+          vendor:
+            op: In
+            value:
+            - "8086"
+    name: intel.gpu.generic.count.380
+  - labels:
+      gpu.intel.com/product: "Max_1100"
+    labelsTemplate: "gpu.intel.com/device.count={{"{{"}} len .pci.device {{"}}"}}"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "0bda"
+    name: intel.gpu.max.1100
+  - labels:
+      gpu.intel.com/product: "Max_1550"
+    labelsTemplate: "gpu.intel.com/device.count={{"{{"}} len .pci.device {{"}}"}}"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "0bd5"
+    name: intel.gpu.max.1550
+  - labels:
+      gpu.intel.com/family: "Max_Series"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "0bda"
+          - "0bd5"
+          - "0bd9"
+          - "0bdb"
+          - "0bd7"
+          - "0bd6"
+          - "0bd0"
+    name: intel.gpu.max.series
+  - labels:
+      gpu.intel.com/family: "Flex_Series"
+      gpu.intel.com/product: "Flex_170"
+    labelsTemplate: "gpu.intel.com/device.count={{"{{"}} len .pci.device {{"}}"}}"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "56c0"
+    name: intel.gpu.flex.170
+  - labels:
+      gpu.intel.com/family: "Flex_Series"
+      gpu.intel.com/product: "Flex_140"
+    labelsTemplate: "gpu.intel.com/device.count={{"{{"}} len .pci.device {{"}}"}}"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0380"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "56c1"
+    name: intel.gpu.flex.140
+  - labels:
+      gpu.intel.com/family: "A_Series"
+    matchFeatures:
+    - feature: pci.device
+      matchExpressions:
+        class:
+          op: In
+          value:
+          - "0300"
+        vendor:
+          op: In
+          value:
+          - "8086"
+        device:
+          op: In
+          value:
+          - "56a6"
+          - "56a5"
+          - "56a1"
+          - "56a0"
+          - "5694"
+          - "5693"
+          - "5692"
+          - "5691"
+          - "5690"
+          - "56b3"
+          - "56b2"
+          - "56a4"
+          - "56a3"
+          - "5697"
+          - "5696"
+          - "5695"
+          - "56b1"
+          - "56b0"
+    name: intel.gpu.a.series
+{{- end }}

--- a/charts/gpu-device-plugin/templates/gpu.yaml
+++ b/charts/gpu-device-plugin/templates/gpu.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
 spec:
   image: "{{ .Values.image.hub }}/intel-gpu-plugin:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  {{- if eq .Values.initImage.enable true }}
   initImage: "{{ .Values.initImage.hub }}/intel-gpu-initcontainer:{{ .Values.initImage.tag | default .Chart.AppVersion }}"
+  {{- end }}
   logLevel:  {{ .Values.logLevel }}
   sharedDevNum: {{ .Values.sharedDevNum }}
   resourceManager: {{ .Values.resourceManager }}

--- a/charts/gpu-device-plugin/values.yaml
+++ b/charts/gpu-device-plugin/values.yaml
@@ -5,6 +5,7 @@ image:
   tag: ""
 
 initImage:
+  enable: false
   hub: intel
   tag: ""
 

--- a/charts/iaa-device-plugin/Chart.yaml
+++ b/charts/iaa-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-iaa
 description: A Helm chart for Intel IAA Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/iaa-device-plugin/README.md
+++ b/charts/iaa-device-plugin/README.md
@@ -33,7 +33,9 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
+| `initImage.hub` | `intel` |
+| `initImage.tag` | `` |
 | `sharedDevNum` | `10` |
 | `logLevel` | `4` |

--- a/charts/qat-device-plugin/Chart.yaml
+++ b/charts/qat-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-qat
 description: A Helm chart for Intel QAT Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/qat-device-plugin/README.md
+++ b/charts/qat-device-plugin/README.md
@@ -38,8 +38,10 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
+| `initImage.hub` | `intel` |
+| `initImage.tag` | `` |
 | `dpdkDriver` | `vfio-pci` |
 | `kernelVfDrivers` | `c6xxvf`, `4xxxvf` |
 | `maxNumDevices` | `128` |

--- a/charts/sgx-device-plugin/Chart.yaml
+++ b/charts/sgx-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-sgx
 description: A Helm chart for Intel SGX Device Plugin
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/charts/sgx-device-plugin/README.md
+++ b/charts/sgx-device-plugin/README.md
@@ -33,8 +33,8 @@ You may also run `helm show values` on this chart's dependencies for additional 
 
 |parameter| value |
 |---------|-----------|
-| `hub` | `intel` |
-| `tag` | `` |
+| `image.hub` | `intel` |
+| `image.tag` | `` |
 | `enclaveLimit` | `110` |
 | `provisionLimit` | `110` |
 | `logLevel` | `4` |


### PR DESCRIPTION
* Updated CRDs
* Added NFD rules for GPU
* GPU InitImage is now disabled by default
* Add nodeSelector for operator
  * And set it to `amd64`
* Updated values in READMEs
* Update version to 0.28.0

Fixes #39