### PR TITLE
gpu: drop empty 'labels' from new rules

### DIFF
--- a/charts/gpu-device-plugin/Chart.yaml
+++ b/charts/gpu-device-plugin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-gpu
 description: A Helm chart for Intel GPU Device Plugin
 type: application
-version: 0.28.0
+version: 0.28.1-helm.0
 appVersion: "0.28.0"

--- a/charts/gpu-device-plugin/templates/gpu.yaml
+++ b/charts/gpu-device-plugin/templates/gpu.yaml
@@ -58,8 +58,7 @@ spec:
           gpu.intel.com/tiles: {op: Exists}
     name: intel.gpu.fractionalresources
   # generic rule for older and upcoming devices
-  - labels:
-    labelsTemplate: |
+  - labelsTemplate: |
       {{"{{"}} range .pci.device {{"}}"}}gpu.intel.com/device-id.{{"{{"}} .class {{"}}"}}-{{"{{"}} .device {{"}}"}}.present=true
       {{"{{"}} end {{"}}"}}
     matchFeatures:
@@ -75,8 +74,7 @@ spec:
             value:
             - "8086"
     name: intel.gpu.generic.deviceid
-  - labels:
-    labelsTemplate: gpu.intel.com/device-id.0300-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
+  - labelsTemplate: gpu.intel.com/device-id.0300-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
     matchFeatures:
       - feature: pci.device
         matchExpressions:
@@ -89,8 +87,7 @@ spec:
             value:
             - "8086"
     name: intel.gpu.generic.count.300
-  - labels:
-    labelsTemplate: gpu.intel.com/device-id.0380-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
+  - labelsTemplate: gpu.intel.com/device-id.0380-{{"{{"}} (index .pci.device 0).device {{"}}"}}.count={{"{{"}} len .pci.device {{"}}"}}
     matchFeatures:
       - feature: pci.device
         matchExpressions:


### PR DESCRIPTION
And bump gpu version to "0.28.1-helm.0"

Fixes #41 