### PR TITLE
move device-plugin-operator resources to values

### DIFF
--- a/charts/device-plugin-operator/templates/operator.yaml
+++ b/charts/device-plugin-operator/templates/operator.yaml
@@ -449,12 +449,7 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          limits:
-            cpu: 100m
-            memory: 120Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/device-plugin-operator/values.yaml
+++ b/charts/device-plugin-operator/values.yaml
@@ -18,3 +18,11 @@ privateRegistry:
   registryUrl: ""
   registryUser: ""
   registrySecret: ""
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 120Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi


### PR DESCRIPTION
Hi team!
In our environment device-plugin-operator sometimes CLBOs due to OOMkill.
Proposing to parametrise resources request/limits as such.

Cheers, Alexey