### PR TITLE
fix: support adding tolerations to the device plugin operator

### DIFF
--- a/charts/device-plugin-operator/templates/operator.yaml
+++ b/charts/device-plugin-operator/templates/operator.yaml
@@ -367,6 +367,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      tolerations: {{ .Values.tolerations | toYaml | nindent 8 }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/device-plugin-operator/values.yaml
+++ b/charts/device-plugin-operator/values.yaml
@@ -26,3 +26,5 @@ resources:
   requests:
     cpu: 100m
     memory: 100Mi
+
+tolerations: []


### PR DESCRIPTION
The deployment should support tolerations for environments where all nodes are tainted

Fixes: #67 