### PR TITLE
device operator: add missing npu roles and webhook configurations

### DIFF
--- a/charts/device-plugin-operator/Chart.yaml
+++ b/charts/device-plugin-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: intel-device-plugins-operator
 description: A Helm chart for Intel Device Plugins Operator for Kubernetes
 type: application
-version: 0.34.0
+version: 0.34.1-helm.0
 appVersion: "0.34.0"

--- a/charts/device-plugin-operator/templates/operator.yaml
+++ b/charts/device-plugin-operator/templates/operator.yaml
@@ -135,6 +135,7 @@ rules:
   - iaadeviceplugins/finalizers
   - qatdeviceplugins/finalizers
   - sgxdeviceplugins/finalizers
+  - npudeviceplugins/finalizers
   verbs:
   - update
 - apiGroups:
@@ -147,6 +148,7 @@ rules:
   - iaadeviceplugins/status
   - qatdeviceplugins/status
   - sgxdeviceplugins/status
+  - npudeviceplugins/status
   verbs:
   - get
   - patch
@@ -513,6 +515,26 @@ webhooks:
     service:
       name: inteldeviceplugins-webhook-service
       namespace: {{ .Release.Namespace | quote }}
+      path: /mutate-deviceplugin-intel-com-v1-npudeviceplugin
+  failurePolicy: Fail
+  name: mnpudeviceplugin.kb.io
+  rules:
+  - apiGroups:
+    - deviceplugin.intel.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - npudeviceplugins
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: inteldeviceplugins-webhook-service
+      namespace: {{ .Release.Namespace | quote }}
       path: /mutate-deviceplugin-intel-com-v1-qatdeviceplugin
   failurePolicy: Fail
   name: mqatdeviceplugin.kb.io
@@ -693,6 +715,26 @@ webhooks:
     - UPDATE
     resources:
     - iaadeviceplugins
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: inteldeviceplugins-webhook-service
+      namespace: {{ .Release.Namespace | quote }}
+      path: /validate-deviceplugin-intel-com-v1-npudeviceplugin
+  failurePolicy: Fail
+  name: vnpudeviceplugin.kb.io
+  rules:
+  - apiGroups:
+    - deviceplugin.intel.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - npudeviceplugins
   sideEffects: None
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
And update helm chart to 0.34.1-helm.0

Fixes #84 